### PR TITLE
fix: pageIinit event not work

### DIFF
--- a/src/utils/vue-router.js
+++ b/src/utils/vue-router.js
@@ -21,7 +21,7 @@ export default {
       routerVue.$nextTick(() => {
         const pageEl = el.children[el.children.length - 1];
         pageData.el = pageEl;
-        resolve(pageEl);
+        resolve(pageEl, { pageEvents: component.on });
       });
     },
     removePage($pageEl) {
@@ -63,7 +63,7 @@ export default {
       });
       tabVue.$nextTick(() => {
         const tabContentEl = tabEl.children[0];
-        resolve(tabContentEl);
+        resolve(tabContentEl, { pageEvents: component.on });
       });
     },
     removeTabContent(tabEl) {


### PR DESCRIPTION
Add pageEvents in ComponentLoader to enable `pageInit`, `pageBeforeRemove` and other custom events.