### PR TITLE
 refactor(pageEvents): let vue component instance bound to pageEvent function

### DIFF
--- a/kitchen-sink/src/pages/action-sheet.vue
+++ b/kitchen-sink/src/pages/action-sheet.vue
@@ -47,40 +47,18 @@ export default {
       self.actionsToPopover.open();
     },
   },
-  on: {
-    pageBeforeRemove() {
-      var self = this;
-      self.actions1.destroy();
-      self.actions2.destroy();
-      self.actionsGrid.destroy();
-      self.actionsToPopover.destroy();
-    },
-    pageInit: function(page) {
-      var self = this;
-
-      // 1 Group
-      var buttons1 = [
-        {
-          text: 'Do something',
-          label: true
-        },
-        {
-          text: 'Button 1',
-          bold: true
-        },
-        {
-          text: 'Button 2',
-        },
-        {
-          text: 'Cancel',
-          color: 'red'
-        },
-      ];
-
-      // 2 Groups
-      var buttons2 = [
-        // First Group
-        [
+  on() {
+    const self = this;
+    return {
+      pageBeforeRemove() {
+        self.actions1.destroy();
+        self.actions2.destroy();
+        self.actionsGrid.destroy();
+        self.actionsToPopover.destroy();
+      },
+      pageInit: function(page) {
+        // 1 Group
+        var buttons1 = [
           {
             text: 'Do something',
             label: true
@@ -91,59 +69,81 @@ export default {
           },
           {
             text: 'Button 2',
-          }
-        ],
-        // Second Group
-        [
+          },
           {
             text: 'Cancel',
             color: 'red'
-          }
+          },
+        ];
+
+        // 2 Groups
+        var buttons2 = [
+          // First Group
+          [
+            {
+              text: 'Do something',
+              label: true
+            },
+            {
+              text: 'Button 1',
+              bold: true
+            },
+            {
+              text: 'Button 2',
+            }
+          ],
+          // Second Group
+          [
+            {
+              text: 'Cancel',
+              color: 'red'
+            }
+          ]
         ]
-      ]
 
-      // Grid buttons with icons/images
-      var gridButtons = [
-        [
-          {
-            text: 'Button 1',
-            icon: '<img src="http://lorempixel.com/96/96/people/1" width="48"/>'
-          },
-          {
-            text: 'Button 2',
-            icon: '<img src="http://lorempixel.com/96/96/people/2" width="48">'
-          },
-          {
-            text: 'Button 3',
-            icon: '<img src="http://lorempixel.com/96/96/people/3" width="48">'
-          },
-        ],
-        [
-          {
-            text: 'Button 1',
-            icon: '<img src="http://lorempixel.com/96/96/fashion/4" width="48"/>'
-          },
-          {
-            text: 'Button 2',
-            icon: '<img src="http://lorempixel.com/96/96/fashion/5" width="48">'
-          },
-          {
-            text: 'Button 3',
-            icon: '<img src="http://lorempixel.com/96/96/fashion/6" width="48">'
-          },
-        ],
-      ]
+        // Grid buttons with icons/images
+        var gridButtons = [
+          [
+            {
+              text: 'Button 1',
+              icon: '<img src="http://lorempixel.com/96/96/people/1" width="48"/>'
+            },
+            {
+              text: 'Button 2',
+              icon: '<img src="http://lorempixel.com/96/96/people/2" width="48">'
+            },
+            {
+              text: 'Button 3',
+              icon: '<img src="http://lorempixel.com/96/96/people/3" width="48">'
+            },
+          ],
+          [
+            {
+              text: 'Button 1',
+              icon: '<img src="http://lorempixel.com/96/96/fashion/4" width="48"/>'
+            },
+            {
+              text: 'Button 2',
+              icon: '<img src="http://lorempixel.com/96/96/fashion/5" width="48">'
+            },
+            {
+              text: 'Button 3',
+              icon: '<img src="http://lorempixel.com/96/96/fashion/6" width="48">'
+            },
+          ],
+        ]
 
-      self.actions1 = self.$f7.actions.create({buttons: buttons1});
-      self.actions2 = self.$f7.actions.create({buttons: buttons2});
-      self.actionsGrid = self.$f7.actions.create({buttons: gridButtons, grid: true});
+        self.actions1 = self.$f7.actions.create({buttons: buttons1});
+        self.actions2 = self.$f7.actions.create({buttons: buttons2});
+        self.actionsGrid = self.$f7.actions.create({buttons: gridButtons, grid: true});
 
-      // Actions To Popover
-      self.actionsToPopover = self.$f7.actions.create({
-        buttons: buttons1,
-        // Need to specify popover target
-        targetEl: self.$el.find('.button-to-popover')
-      });
+        // Actions To Popover
+        self.actionsToPopover = self.$f7.actions.create({
+          buttons: buttons1,
+          // Need to specify popover target
+          targetEl: self.$el.find('.button-to-popover')
+        });
+      }
     }
   }
 }

--- a/kitchen-sink/src/pages/messages.vue
+++ b/kitchen-sink/src/pages/messages.vue
@@ -248,36 +248,37 @@ export default {
       }, 1000);
     },
   },
-  on: {
-    pageBeforeRemove: function (e, page) {
-      var self = this;
-      if (self.messagebar) self.messagebar.destroy();
-    },
-    pageInit: function (e, page) {
-      var self = this;
-      var app = self.$f7;
-      self.messagebar = app.messagebar.create({
-        el: page.$el.find('.messagebar'),
-        attachments: []
-      })
-      self.messages = app.messages.create({
-        el: page.$el.find('.messages'),
-        firstMessageRule: function (message, previousMessage, nextMessage) {
-          if (message.isTitle) return false;
-          if (!previousMessage || previousMessage.type !== message.type || previousMessage.name !== message.name) return true;
-          return false;
-        },
-        lastMessageRule: function (message, previousMessage, nextMessage) {
-          if (message.isTitle) return false;
-          if (!nextMessage || nextMessage.type !== message.type || nextMessage.name !== message.name) return true;
-          return false;
-        },
-        tailMessageRule: function (message, previousMessage, nextMessage) {
-          if (message.isTitle) return false;
-          if (!nextMessage || nextMessage.type !== message.type || nextMessage.name !== message.name) return true;
-          return false;
-        }
-      })
+  on() {
+    const self = this;
+    return {
+      pageBeforeRemove: function (e, page) {
+        if (self.messagebar) self.messagebar.destroy();
+      },
+      pageInit: function (e, page) {
+        var app = self.$f7;
+        self.messagebar = app.messagebar.create({
+          el: page.$el.find('.messagebar'),
+          attachments: []
+        })
+        self.messages = app.messages.create({
+          el: page.$el.find('.messages'),
+          firstMessageRule: function (message, previousMessage, nextMessage) {
+            if (message.isTitle) return false;
+            if (!previousMessage || previousMessage.type !== message.type || previousMessage.name !== message.name) return true;
+            return false;
+          },
+          lastMessageRule: function (message, previousMessage, nextMessage) {
+            if (message.isTitle) return false;
+            if (!nextMessage || nextMessage.type !== message.type || nextMessage.name !== message.name) return true;
+            return false;
+          },
+          tailMessageRule: function (message, previousMessage, nextMessage) {
+            if (message.isTitle) return false;
+            if (!nextMessage || nextMessage.type !== message.type || nextMessage.name !== message.name) return true;
+            return false;
+          }
+        })
+      }
     }
   }
 }

--- a/kitchen-sink/src/pages/photo-browser.vue
+++ b/kitchen-sink/src/pages/photo-browser.vue
@@ -80,48 +80,49 @@
         self.pageDark.open();
       },
     },
-    on: {
-      pageInit: function () {
-        const self = this;
-        // Create PBs when page init
-        self.standalone = self.$f7.photoBrowser.create({
-          photos: self.photos,
-        });
-        self.popup = self.$f7.photoBrowser.create({
-          photos: self.photos,
-          type: 'popup',
-        });
-        self.page = self.$f7.photoBrowser.create({
-          photos: self.photos,
-          type: 'page',
-          backLinkText: 'Back',
-        });
-        self.standaloneDark = self.$f7.photoBrowser.create({
-          photos: self.photos,
-          theme: 'dark',
-        });
-        self.popupDark = self.$f7.photoBrowser.create({
-          photos: self.photos,
-          type: 'popup',
-          theme: 'dark',
-        });
-        self.pageDark = self.$f7.photoBrowser.create({
-          photos: self.photos,
-          type: 'page',
-          backLinkText: 'Back',
-          theme: 'dark',
-        });
-      },
-      pageBeforeRemove: function () {
-        const self = this;
-        // Destroy PBs on page remove
-        self.standalone.destroy();
-        self.popup.destroy();
-        self.page.destroy();
-        self.standaloneDark.destroy();
-        self.popupDark.destroy();
-        self.pageDark.destroy();
-      },
+    on() {
+      const self = this;
+      return {
+        pageInit: function () {
+          // Create PBs when page init
+          self.standalone = self.$f7.photoBrowser.create({
+            photos: self.photos,
+          });
+          self.popup = self.$f7.photoBrowser.create({
+            photos: self.photos,
+            type: 'popup',
+          });
+          self.page = self.$f7.photoBrowser.create({
+            photos: self.photos,
+            type: 'page',
+            backLinkText: 'Back',
+          });
+          self.standaloneDark = self.$f7.photoBrowser.create({
+            photos: self.photos,
+            theme: 'dark',
+          });
+          self.popupDark = self.$f7.photoBrowser.create({
+            photos: self.photos,
+            type: 'popup',
+            theme: 'dark',
+          });
+          self.pageDark = self.$f7.photoBrowser.create({
+            photos: self.photos,
+            type: 'page',
+            backLinkText: 'Back',
+            theme: 'dark',
+          });
+        },
+        pageBeforeRemove: function () {
+          // Destroy PBs on page remove
+          self.standalone.destroy();
+          self.popup.destroy();
+          self.page.destroy();
+          self.standaloneDark.destroy();
+          self.popupDark.destroy();
+          self.pageDark.destroy();
+        },
+      }
     }
   };
 </script>

--- a/kitchen-sink/src/pages/popup.vue
+++ b/kitchen-sink/src/pages/popup.vue
@@ -65,12 +65,14 @@
         self.popup.open();
       },
     },
-    on: {
-      pageBeforeRemove: function () {
-        var self = this;
-        // Destroy popup when page removed
-        if (self.popup) self.popup.destroy();
-      },
+    on() {
+      const self = this;
+      return {
+        pageBeforeRemove: function () {
+          // Destroy popup when page removed
+          if (self.popup) self.popup.destroy();
+        },
+      }
     }
   }
 </script>

--- a/kitchen-sink/src/pages/sheet-modal.vue
+++ b/kitchen-sink/src/pages/sheet-modal.vue
@@ -66,17 +66,18 @@ export default {
       self.sheet.open();
     },
   },
-  on: {
-    pageBeforeOut: function () {
-      var self = this;
-      // Close opened sheets on page out
-      self.$f7.sheet.close();
-    },
-    pageBeforeRemove: function () {
-      var self = this;
-      // Destroy sheet modal when page removed
-      if (self.sheet) self.sheet.destroy();
-    },
+  on() {
+    const self = this;
+    return {
+      pageBeforeOut: function () {
+        // Close opened sheets on page out
+        self.$f7.sheet.close();
+      },
+      pageBeforeRemove: function () {
+        // Destroy sheet modal when page removed
+        if (self.sheet) self.sheet.destroy();
+      },
+    }
   }
 }
 </script>

--- a/kitchen-sink/src/pages/swipeout.vue
+++ b/kitchen-sink/src/pages/swipeout.vue
@@ -338,37 +338,38 @@
         app.dialog.alert('Thanks, item removed!');
       },
     },
-    on: {
-      pageBeforeRemove() {
-        var self = this;
-        self.actions.destroy();
-      },
-      pageInit: function () {
-        var self = this;
-        var app = self.$f7;
-        self.actions = app.actions.create({
-          buttons: [
-            [
-              {
-                text: 'Here comes some optional description or warning for actions below',
-                label: true,
-              },
-              {
-                text: 'Action 1',
-              },
-              {
-                text: 'Action 2',
-              },
+    on() {
+      const self = this;
+      return {
+        pageBeforeRemove() {
+          self.actions.destroy();
+        },
+        pageInit: function () {
+          var app = self.$f7;
+          self.actions = app.actions.create({
+            buttons: [
+              [
+                {
+                  text: 'Here comes some optional description or warning for actions below',
+                  label: true,
+                },
+                {
+                  text: 'Action 1',
+                },
+                {
+                  text: 'Action 2',
+                },
+              ],
+              [
+                {
+                  text: 'Cancel',
+                  bold: true,
+                }
+              ]
             ],
-            [
-              {
-                text: 'Cancel',
-                bold: true,
-              }
-            ]
-          ],
-        })
-      },
+          })
+        },
+      }
     }
   }
 </script>

--- a/kitchen-sink/src/pages/virtual-list.vue
+++ b/kitchen-sink/src/pages/virtual-list.vue
@@ -54,41 +54,42 @@
         items: items
       };
     },
-    on: {
-      pageBeforeRemove: function () {
-        var self = this;
-        self.virtualList.destroy();
-      },
-      pageInit: function() {
-        var self = this;
-        self.virtualList = self.$f7.virtualList.create({
-          // List Element
-          el: self.$el.find('.virtual-list'),
-          // Pass array with items
-          items: self.items,
-          // Custom search function for searchbar
-          searchAll: function (query, items) {
-            var found = [];
-            for (var i = 0; i < items.length; i++) {
-              if (items[i].title.toLowerCase().indexOf(query.toLowerCase()) >= 0 || query.trim() === '') found.push(i);
-            }
-            return found; //return array with mathced indexes
-          },
-          // List item Template7 template
-          itemTemplate:
-            '<li>' +
-              '<a href="#" class="item-link item-content">' +
-                '<div class="item-inner">' +
-                  '<div class="item-title-row">' +
-                    '<div class="item-title">{{title}}</div>' +
+    on() {
+      const self = this;
+      return {
+        pageBeforeRemove: function () {
+          self.virtualList.destroy();
+        },
+        pageInit: function() {
+          self.virtualList = self.$f7.virtualList.create({
+            // List Element
+            el: self.$el.find('.virtual-list'),
+            // Pass array with items
+            items: self.items,
+            // Custom search function for searchbar
+            searchAll: function (query, items) {
+              var found = [];
+              for (var i = 0; i < items.length; i++) {
+                if (items[i].title.toLowerCase().indexOf(query.toLowerCase()) >= 0 || query.trim() === '') found.push(i);
+              }
+              return found; //return array with mathced indexes
+            },
+            // List item Template7 template
+            itemTemplate:
+              '<li>' +
+                '<a href="#" class="item-link item-content">' +
+                  '<div class="item-inner">' +
+                    '<div class="item-title-row">' +
+                      '<div class="item-title">{{title}}</div>' +
+                    '</div>' +
+                    '<div class="item-subtitle">{{subtitle}}</div>' +
                   '</div>' +
-                  '<div class="item-subtitle">{{subtitle}}</div>' +
-                '</div>' +
-              '</a>' +
-            '</li>',
-          // Item height
-          height: self.$theme.ios ? 63 : 73,
-        });
+                '</a>' +
+              '</li>',
+            // Item height
+            height: self.$theme.ios ? 63 : 73,
+          });
+        }
       }
     }
   }

--- a/src/utils/vue-router.js
+++ b/src/utils/vue-router.js
@@ -21,7 +21,11 @@ export default {
       routerVue.$nextTick(() => {
         const pageEl = el.children[el.children.length - 1];
         pageData.el = pageEl;
-        resolve(pageEl, { pageEvents: component.on });
+        let pageEvents = component.on;
+        if (typeof pageEvents === 'function') {
+          pageEvents = pageEvents.apply(routerVue);
+        }
+        resolve(pageEl, { pageEvents });
       });
     },
     removePage($pageEl) {
@@ -63,7 +67,11 @@ export default {
       });
       tabVue.$nextTick(() => {
         const tabContentEl = tabEl.children[0];
-        resolve(tabContentEl, { pageEvents: component.on });
+        let pageEvents = component.on;
+        if (typeof pageEvents === 'function') {
+          pageEvents = pageEvents.apply(tabVue);
+        }
+        resolve(tabContentEl, { pageEvents });
       });
     },
     removeTabContent(tabEl) {


### PR DESCRIPTION
The event functions such like `pageInit`, `pageBeforeRemove` are hard to get vue instance, so I add feature that make the `on` could be function and bind to vue component.
```js
export default {
    methods: {
      openStandalone: function () {
        const self = this;
        self.standalone.open();
      },
    },
    on: {
        pageInit: function () {
          const self = this
          // before this change, `self` was the dom object, will get error
          self.standalone = self.$f7.photoBrowser.create({
            photos: self.photos,
          });
        },
    }
    on() {
      const self = this;
      return {
        pageInit: function () {
          // now, self is vue instance, `openStandalone` become available
          self.standalone = self.$f7.photoBrowser.create({
            photos: self.photos,
          });
        },
      }
    }
  };
```