### PR TITLE
fix: TypeError: Cannot read property 'trigger' of undefined

### DIFF
--- a/src/components/toggle.vue
+++ b/src/components/toggle.vue
@@ -46,7 +46,7 @@
     },
     beforeDestroy() {
       const self = this;
-      if (self.f7Toggle && self.f7Toggle.destroy) self.f7Toggle.destroy();
+      if (self.f7Toggle && self.f7Toggle.destroy && self.f7Toggle.$el) self.f7Toggle.destroy();
     },
     methods: {
       toggle() {


### PR DESCRIPTION
Beacuse we have enable `on` events, so `toggle` component will be destroyed  in https://github.com/framework7io/Framework7/blob/v2/src/components/toggle/toggle.js#L45-L48.
So I add check for dom to avoid error caused by duplicate destruction , but I think maybe the `beforeDestroy` can be removed directly, pls feel free to discuss with me.