### PR TITLE
-issue#299: progressbar doesn't work properly

### DIFF
--- a/src/components/progressbar.vue
+++ b/src/components/progressbar.vue
@@ -11,7 +11,8 @@
       }, [
         c('span', {
           style: {
-            'transform': progress ? 'translate3d(' + (-100 + progress) + '%,0,0)' : ''
+            'transform': progress ? 'translate3d(' + (-100 + progress) + '%,0,0)' : '',
+            '-webkit-transform': progress ? 'translate3d(' + (-100 + progress) + '%,0,0)' : ''
           }
         })
       ]);


### PR DESCRIPTION
progressbar doesn't work properly if css transform property isn't supported by a browser